### PR TITLE
[docs] Improve quickstart instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ machine. This is especially useful if you need to:
 
 You will need these core pieces:
 
-1. Docker
+1. [Docker](https://docs.docker.com/engine/install/)
 2. OpenAI [API key](https://openai.com/index/openai-api/)
 
 Optional:
@@ -56,7 +56,7 @@ instructions for dynamically adding and working with tools. Try a conversation
 like this:
 
 ```text
-    you) What tools are available?_
+    you) What tools are available?
 
     Here are the tools that are available for use:
 


### PR DESCRIPTION
Really the Google Client and AWS steps would have links too.